### PR TITLE
New pipeline windows support

### DIFF
--- a/accelerate-llvm-native/Setup.hs
+++ b/accelerate-llvm-native/Setup.hs
@@ -65,6 +65,7 @@ quote :: String -> String
 #ifdef mingw32_HOST_OS
 quote s = "\"" ++ (s >>= escape) ++ "\""
   where
+    escape '\\' = "\\\\"
     escape '"' = "\\\""
     escape c   = [c]
 #else

--- a/accelerate-llvm-native/cbits/queue.cpp
+++ b/accelerate-llvm-native/cbits/queue.cpp
@@ -7,7 +7,7 @@
 // Should be in sync with Task in ./types.h (that file is not included here to prevent C vs C++ issues)
 struct Task {
   void* program;
-  uint location;
+  unsigned int location;
 };
 typedef moodycamel::ConcurrentQueue<Task> Queue;
 

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
@@ -271,7 +271,9 @@ compile uid name module' = do
           -- gets pulled in even if the main executable is statically-linked and
           -- thus does not have a dynamic libm in its address space.)
           then callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-undefined", "dynamic_lookup"]
-          else callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-lm"]
+          else if Info.os == "mingw32" -- Windows
+            then callProcess ld ["--shared", "-o", sharedObjFile, objFile]
+            else callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-lm"]
         Debug.traceM Debug.dump_cc ("cc: new shared object " % shown) uid
 
     return sharedObjFile

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
@@ -271,7 +271,9 @@ compile uid name module' = do
           -- gets pulled in even if the main executable is statically-linked and
           -- thus does not have a dynamic libm in its address space.)
           then callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-undefined", "dynamic_lookup"]
-          else if Info.os == "mingw32" -- Windows
+          else if Info.os == "mingw32"
+            -- On windows linking with the math library (-lm) is not needed.
+            -- The math functions are already defined in the MinGW standard library.
             then callProcess ld ["--shared", "-o", sharedObjFile, objFile]
             else callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-lm"]
         Debug.traceM Debug.dump_cc ("cc: new shared object " % shown) uid


### PR DESCRIPTION
## Description
Adds Windows support on the new pipeline.

## Motivation and context
The new pipeline did not work on Windows.

## How has this been tested?
The following benchmarks were run on several Windows machines using clang 19 and CBC 2.10.
**NOTE**: Cuda support has not been tested.

- _MG_ from: [CFAL-bench-new-accelerate](https://github.com/ivogabe/CFAL-bench-new-accelerate)
- _nbody-naive_ from: [CFAL-bench-new-accelerate](https://github.com/ivogabe/CFAL-bench-new-accelerate)
- _quickhull_ from: [quickhull-benchmarks](https://github.com/ivogabe/quickhull-benchmarks)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

