### PR TITLE
Data-parallel work stealing for parallel loops

### DIFF
--- a/accelerate-llvm-native/cbits/runtime.c
+++ b/accelerate-llvm-native/cbits/runtime.c
@@ -53,6 +53,49 @@ void accelerate_parker_wake_all(struct ThreadParker *parker) {
   pthread_mutex_unlock(&parker->lock);
 }
 
+// Claims an entry from Workers.work_per_thread_array.
+// Note that this claims one array, to be used for scheduling within a kernel.
+// It does not claim the actual work within that kernel.
+// See comment on Workers.work_per_thread_array
+inline _Atomic uint64_t* accelerate_work_per_thread_claim(struct Workers *workers, uint16_t thread_idx) {
+  uint16_t thread_count = workers->thread_count;
+  int16_t inc = (thread_idx % 2 == 0) ? 1 : (thread_count - 1);
+  int16_t i = thread_idx;
+
+  // This loop will terminate, because:
+  // Each thread may only 'own' one work_per_thread at a time.
+  // There are thread_count work_per_threads.
+  // A thread cannot call accelerate_work_per_thread_claim when it already owns
+  // one.
+  // Hence there will be at least one free entry; we just need to find it.
+  // Note that due to concurrent access, which entry is free may change during
+  // the execution of the function. We just know that at any point in time, at
+  // least one entry will be free.
+  while (true) {
+    uint16_t slot_idx = i / 64;
+    uint16_t bit_idx = i % 64;
+
+    // If this ever becomes a bottleneck, we can optimize this code by using
+    // the fact that multiple bits are in one uint64. We can for instance
+    // find a free spot directly using count-leading-zeros over the bitwise negated value,
+    // instead of individually trying all bits via atomic_fetch_or_explicit.
+    uint64_t old = atomic_fetch_or_explicit(&workers->work_per_thread_free[slot_idx], 1 << bit_idx, memory_order_acquire);
+    if ((old & (1 << bit_idx)) != 0) {
+      return &workers->work_per_thread_array[i * thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE];
+    }
+
+    i += inc;
+    if (i >= thread_count) i -= thread_count;
+  }
+}
+
+inline void accelerate_work_per_thread_free(struct Workers *workers, _Atomic uint64_t *work_per_thread) {
+  int16_t idx = (work_per_thread - workers->work_per_thread_array) / (workers->thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE);
+  uint16_t slot_idx = idx / 64;
+  uint16_t bit_idx = idx % 64;
+  atomic_fetch_and_explicit(&workers->work_per_thread_free[slot_idx], ~(1 << bit_idx), memory_order_release);
+}
+
 #define ATTEMPTS 16
 
 void* accelerate_worker(void *data_packed) {
@@ -97,6 +140,7 @@ void* accelerate_worker(void *data_packed) {
         task.program = NULL;
         task.location = 0;
       } else {
+        kernel->work_per_thread = accelerate_work_per_thread_claim(workers, thread_idx);
         // Initialize kernel memory and check if the kernel should be executed in parallel.
         TRACY_ZONE_BEGIN(init_ctx, kernel->tracy_srcloc, COLOR_LIGHT);
         unsigned char parallel =
@@ -165,6 +209,8 @@ void* accelerate_worker(void *data_packed) {
           TRACY_ZONE_BEGIN(final_ctx, kernel->tracy_srcloc, COLOR_LIGHT);
           kernel->work_function(kernel, workers->locks, 0xFFFFFFFE, workers->thread_count);
           TRACY_ZONE_END(final_ctx);
+          // Recycle work_per_thread for later kernels
+          accelerate_work_per_thread_free(workers, kernel->work_per_thread);
           // Then continue the program after this kernel, via
           // program_continuation in the KernelLaunch structure.
           task.program = kernel->program;
@@ -181,13 +227,12 @@ void* accelerate_worker(void *data_packed) {
     // Try assisting with the data-parallel activity (KernelLaunch) from another thread.
     // try_assist from the Work Assisting paper
     uint16_t thread_count = workers->thread_count;
-    int16_t inc = (thread_idx % 2 == 0) ? 1 : -1;
+    int16_t inc = (thread_idx % 2 == 0) ? 1 : (thread_count - 1);
     int16_t other_thread = thread_idx;
     bool workassisting_found = false;
     while (true) {
       other_thread += inc;
-      while (other_thread >= thread_count) other_thread -= thread_count;
-      if (other_thread < 0) other_thread += thread_count;
+      if (other_thread >= thread_count) other_thread -= thread_count;
       if (other_thread == thread_idx) break;
 
       _Atomic(uintptr_t) *ptr = &workers->scheduler.activities[other_thread];
@@ -235,6 +280,8 @@ void* accelerate_worker(void *data_packed) {
         TRACY_ZONE_BEGIN(final_ctx, kernel->tracy_srcloc, COLOR_DARK);
         kernel->work_function(kernel, workers->locks, 0xFFFFFFFE, workers->thread_count);
         TRACY_ZONE_END(final_ctx);
+        // Recycle work_per_thread for later kernels
+        accelerate_work_per_thread_free(workers, kernel->work_per_thread);
         // Then continue the program after this kernel, via
         // program_continuation in the KernelLaunch structure.
         task.program = kernel->program;
@@ -272,16 +319,15 @@ struct Workers* accelerate_start_workers(uint64_t thread_count) {
     exit(1);                                                                    
   }
 
-  workers->scheduler.activities = malloc(sizeof(uintptr_t) * thread_count);
+  workers->scheduler.activities = calloc(thread_count, sizeof(uintptr_t));
 
   workers->thread_count = thread_count;
 
   // ACCELERATE_LOCK_ARRAY_SIZE is measured in bits, convert to bytes.
   workers->locks = calloc(ACCELERATE_LOCK_ARRAY_SIZE / 8, 1);
 
-  for (uint64_t i = 0; i < thread_count; i++) {
-    workers->scheduler.activities[i] = 0;
-  }
+  workers->work_per_thread_array = calloc(thread_count * thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE, sizeof(uint64_t));
+  workers->work_per_thread_free = calloc((thread_count + 63) / 64, sizeof(uint64_t));
 
   for (uint64_t i = 0; i < thread_count; i++) {
     // TODO: Check if setting thread affinities helps

--- a/accelerate-llvm-native/cbits/runtime.c
+++ b/accelerate-llvm-native/cbits/runtime.c
@@ -100,7 +100,7 @@ void* accelerate_worker(void *data_packed) {
         // Initialize kernel memory and check if the kernel should be executed in parallel.
         TRACY_ZONE_BEGIN(init_ctx, kernel->tracy_srcloc, COLOR_LIGHT);
         unsigned char parallel =
-          kernel->work_function(kernel, workers->locks, 0xFFFFFFFF);
+          kernel->work_function(kernel, workers->locks, 0xFFFFFFFF, workers->thread_count);
         TRACY_ZONE_END(init_ctx);
 
         // start_task from the Work Assisting paper
@@ -110,7 +110,7 @@ void* accelerate_worker(void *data_packed) {
         }
 
         TRACY_ZONE_BEGIN(work_ctx, kernel->tracy_srcloc, COLOR_NORMAL);
-        kernel->work_function(kernel, workers->locks, 0);
+        kernel->work_function(kernel, workers->locks, thread_idx, workers->thread_count);
         TRACY_ZONE_END(work_ctx);
 
         // Keep track of whether this was the last thread working on the kernel
@@ -163,7 +163,7 @@ void* accelerate_worker(void *data_packed) {
           // The last thread executes the finish function.
           // First, execute the finish procedure of the kernel:
           TRACY_ZONE_BEGIN(final_ctx, kernel->tracy_srcloc, COLOR_LIGHT);
-          kernel->work_function(kernel, workers->locks, 0xFFFFFFFE);
+          kernel->work_function(kernel, workers->locks, 0xFFFFFFFE, workers->thread_count);
           TRACY_ZONE_END(final_ctx);
           // Then continue the program after this kernel, via
           // program_continuation in the KernelLaunch structure.
@@ -199,10 +199,9 @@ void* accelerate_worker(void *data_packed) {
       if (attempts_remaining == 0) {
         accelerate_parker_cancel_park(&workers->scheduler.parker);
       }
-      uint32_t i = atomic_fetch_add_explicit(&kernel->work_index, 1, memory_order_relaxed);
 
       TRACY_ZONE_BEGIN(steal_ctx, kernel->tracy_srcloc, COLOR_DARK);
-      kernel->work_function(kernel, workers->locks, i);
+      kernel->work_function(kernel, workers->locks, thread_idx, workers->thread_count);
       TRACY_ZONE_END(steal_ctx);
 
       // signal_task_empty from the Work Assisting paper,
@@ -234,7 +233,7 @@ void* accelerate_worker(void *data_packed) {
         // The last thread executes the finish function.
         // First, execute the finish procedure of the kernel:
         TRACY_ZONE_BEGIN(final_ctx, kernel->tracy_srcloc, COLOR_DARK);
-        kernel->work_function(kernel, workers->locks, 0xFFFFFFFE);
+        kernel->work_function(kernel, workers->locks, 0xFFFFFFFE, workers->thread_count);
         TRACY_ZONE_END(final_ctx);
         // Then continue the program after this kernel, via
         // program_continuation in the KernelLaunch structure.

--- a/accelerate-llvm-native/cbits/runtime.c
+++ b/accelerate-llvm-native/cbits/runtime.c
@@ -79,8 +79,9 @@ inline _Atomic uint64_t* accelerate_work_per_thread_claim(struct Workers *worker
     // the fact that multiple bits are in one uint64. We can for instance
     // find a free spot directly using count-leading-zeros over the bitwise negated value,
     // instead of individually trying all bits via atomic_fetch_or_explicit.
-    uint64_t old = atomic_fetch_or_explicit(&workers->work_per_thread_free[slot_idx], 1 << bit_idx, memory_order_acquire);
-    if ((old & (1 << bit_idx)) != 0) {
+    uint64_t bit = ((uint64_t) 1) << bit_idx;
+    uint64_t old = atomic_fetch_or_explicit(&workers->work_per_thread_free[slot_idx], bit, memory_order_acquire);
+    if ((old & bit) == 0) {
       return &workers->work_per_thread_array[i * thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE];
     }
 
@@ -93,7 +94,8 @@ inline void accelerate_work_per_thread_free(struct Workers *workers, _Atomic uin
   int16_t idx = (work_per_thread - workers->work_per_thread_array) / (workers->thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE);
   uint16_t slot_idx = idx / 64;
   uint16_t bit_idx = idx % 64;
-  atomic_fetch_and_explicit(&workers->work_per_thread_free[slot_idx], ~(1 << bit_idx), memory_order_release);
+  uint64_t bit = ((uint64_t) 1) << bit_idx;
+  atomic_fetch_and_explicit(&workers->work_per_thread_free[slot_idx], ~bit, memory_order_release);
 }
 
 #define ATTEMPTS 16
@@ -154,7 +156,7 @@ void* accelerate_worker(void *data_packed) {
         }
 
         TRACY_ZONE_BEGIN(work_ctx, kernel->tracy_srcloc, COLOR_NORMAL);
-        kernel->work_function(kernel, workers->locks, thread_idx, workers->thread_count);
+        kernel->work_function(kernel, workers->locks, parallel == 1 ? thread_idx : 0, parallel == 1 ? workers->thread_count : 1);
         TRACY_ZONE_END(work_ctx);
 
         // Keep track of whether this was the last thread working on the kernel

--- a/accelerate-llvm-native/cbits/types.h
+++ b/accelerate-llvm-native/cbits/types.h
@@ -145,7 +145,7 @@ inline uint16_t accelerate_unpack_tag(uintptr_t packed) {
 // locks: an array of locks that can be used by any permutes in the kernel.
 // This array is global, i.e. all kernels use the same array of locks, and is
 // taken from Workers.locks.
-typedef unsigned char KernelFunction(struct KernelLaunch *kernel, uint8_t *locks, uint32_t first_index);
+typedef unsigned char KernelFunction(struct KernelLaunch *kernel, uint8_t *locks, uint32_t thread_index, uint32_t max_thread_count);
 struct KernelLaunch {
   KernelFunction *work_function;
   struct Program *program;

--- a/accelerate-llvm-native/cbits/types.h
+++ b/accelerate-llvm-native/cbits/types.h
@@ -8,6 +8,10 @@
 #include <pthread.h>
 
 #define ACCELERATE_LOCK_ARRAY_SIZE (16 * 1024 * 8)
+// Stride used in KernelLaunch.work_per_thread.
+// By using a higher stride than 1, we prevent false sharing between cache
+// lines.
+#define ACCELERATE_WORK_PER_THREAD_STRIDE (8)
 
 struct Workers;
 struct Program;
@@ -82,6 +86,16 @@ struct Workers {
   // A permute will need to map indices of the array to indices in the array of
   // locks.
   uint8_t *locks;
+  // Array of work_per_thread arrays. Each kernel launch needs such an array,
+  // which we will take from this array. 
+  // work_per_thread has size thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE
+  // items, and we need at most thread_count of those concurrently.
+  // Hence we represent work_per_thread_array as a flattened array of
+  // thread_count * thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE items. 
+  _Atomic(uint64_t)* work_per_thread_array;
+  // Bitset of all entries in work_per_thread_array that are free.
+  // This contains thread_count bits, thus ceil(thread_count/64) fields.
+  _Atomic(uint64_t)* _Atomic work_per_thread_free;
 };
 
 struct Signal {
@@ -152,6 +166,13 @@ struct KernelLaunch {
   uint32_t program_continuation;
   _Atomic int32_t active_threads;
   _Atomic uint64_t work_index;
+  // Pointer to an array with thread_count values, with stride ACCELERATE_WORK_PER_THREAD_STRIDE.
+  // Total size of the array is thus thread_count * ACCELERATE_WORK_PER_THREAD_STRIDE.
+  // At the beginning of the kernel launch, all slots must be initialized to zero.
+  // During execution of the function, the work function uses this array to store which thread has claimed
+  // which part of the array. In a data-parallel work stealer, this replaces the per-thread queues
+  // (and encodes the per thread state in a single uint64 instead of an array or other queue datastructure).
+  _Atomic uint64_t *work_per_thread;
   const struct ___tracy_source_location_data *tracy_srcloc;
   // In the future, perhaps also store a uint32_t work_size
   uint8_t args[0]; // Actual type will be different. Only use this field to get a pointer to the arguments.

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
@@ -85,7 +85,7 @@ codegen name env cluster args
  | flat@(FlatCluster shr idxLHS sizes dirs localR localLHS flatOps) <- toFlatClustered cluster args
  , parallelDepth <- flatClusterIndependentLoopDepth flat
  , Exists parallelShr <- shapeRFromRank parallelDepth =
-  codeGenFunction linkage name type' (LLVM.Lam argTp "arg" . LLVM.Lam primType "locks_array" . LLVM.Lam primType "workassist.first_index") $ do
+  codeGenFunction linkage name type' (LLVM.Lam argTp "arg" . LLVM.Lam primType "locks_array" . LLVM.Lam primType "thread.index" . LLVM.Lam primType "thread.count") $ do
     extractEnv
 
     -- Before the parallel work of a kernel is started, we first run the function once.
@@ -94,7 +94,7 @@ codegen name env cluster args
     initBlock <- newBlock "init"
     finishBlock <- newBlock "finish" -- Finish function from the work assisting paper
     workBlock <- newBlock "work"
-    _ <- switch (OP_Word64 workassistFirstIndex) workBlock [(0xFFFFFFFF, initBlock), (0xFFFFFFFE, finishBlock)]
+    _ <- switch (OP_Word32 threadIndex) workBlock [(0xFFFFFFFF, initBlock), (0xFFFFFFFE, finishBlock)]
     let hasPermute = hasNPermute flat
 
     if parallelDepth == 0 && rank shr /= 0 then do
@@ -180,7 +180,7 @@ codegen name env cluster args
             -- here.
             bindLocals 0 envs' >>=
             bindLocalsInTile (\_ -> not $ null $ ptOtherLoops tileLoops) 1 tileSize
-          workassistLoop workassistIndex workassistFirstIndex tileCount $ \seqMode tileIdx' -> do
+          workassistLoop workassistIndex threadIndex threadCount tileCount $ \seqMode tileIdx' -> do
             tileIdx <- instr' $ BitCast scalarType tileIdx'
             (_, lower, upper, _) <- tileRange (isDescending direction) (op TypeInt size) (integral TypeInt tileSize) tileCount' tileIdx
 
@@ -302,7 +302,7 @@ codegen name env cluster args
             if parallelDepth /= rank shr then []
             else {- if hasPermute then -} [Loop.LoopInterleave]
             -- else [Loop.LoopVectorize]
-      workassistChunked ann parallelShr workassistIndex workassistFirstIndex tileSize parSizes $ \idx -> do
+      workassistChunked ann parallelShr workassistIndex threadIndex threadCount tileSize parSizes $ \idx -> do
         let envs' = envs{
             envsLoopDepth = parallelDepth,
             envsIdx =
@@ -316,7 +316,7 @@ codegen name env cluster args
 
       pure 0
   where
-    (argTp, extractEnv, workassistIndex, workassistFirstIndex, kernelMem', gamma) = bindHeaderEnv env
+    (argTp, extractEnv, workassistIndex, threadIndex {- or flag -}, threadCount, kernelMem', gamma) = bindHeaderEnv env
 
     isDescending :: LoopDirection Int -> Bool
     isDescending LoopDescending = True

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
@@ -48,10 +48,12 @@ import Data.Array.Accelerate.LLVM.CodeGen.Environment hiding ( Empty )
 import Data.Array.Accelerate.LLVM.CodeGen.Cluster
 import Data.Array.Accelerate.LLVM.CodeGen.Default
 import Data.Array.Accelerate.LLVM.CodeGen.Loop
+import Data.Array.Accelerate.LLVM.CodeGen.Intrinsic
 import Data.Array.Accelerate.LLVM.Native.Operation
 import Data.Array.Accelerate.LLVM.Native.CodeGen.Base
 import Data.Array.Accelerate.LLVM.Native.Target
 import Data.Maybe
+import Data.Bits
 
 import LLVM.AST.Type.Module
 import LLVM.AST.Type.Representation
@@ -139,6 +141,10 @@ codegen name env cluster args
             -- Initialize kernel memory
             parCodeGenInitMemory kernelMem envs' TupleIdxSelf parCodes
             -- Decide whether tileCount is large enough
+
+            -- Assert that there are at most 2^47 tiles
+            A.when (A.gt singleType (OP_Int tileCount') $ A.liftInt (1 `shiftL` 47)) $
+              trapWithMessage "Accelerate: Parallel loops must have at most 2^47 tiles"
 
             OP_Bool isSmall <- A.lt singleType (OP_Int tileCount') $ A.liftInt 2
             value <- instr' $ LLVM.Select isSmall (scalar (scalarType @Word8) 0) (scalar scalarType 1)
@@ -293,6 +299,10 @@ codegen name env cluster args
         tileCount <- chunkCount parallelShr parSizes (A.lift (shapeType parallelShr) tileSize)
         tileCount' <- shapeSize parallelShr tileCount
         -- We are not using kernel memory, so no need to initialize it.
+
+        -- Assert that there are at most 2^47 tiles
+        A.when (A.gt singleType tileCount' $ A.liftInt (1 `shiftL` 47)) $
+          trapWithMessage "Accelerate: Parallel loops must have at most 2^47 tiles"
 
         OP_Bool isSmall <- A.lt singleType tileCount' $ A.liftInt 2
         value <- instr' $ LLVM.Select isSmall (scalar (scalarType @Word8) 0) (scalar scalarType 1)

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
@@ -518,9 +518,7 @@ parCodeGenFoldCommutative _ fun seed identity input output inputIdx outputIdx = 
         tupleStore tp valuePtrs new
 
         -- Release the lock
-        _ <- instr' $ LLVM.Fence (CrossThread, Release)
-        -- TODO: Change to atomic store
-        _ <- instr' $ Store Volatile lock (scalar scalarTypeWord8 0) Nothing
+        _ <- instr' $ AtomicStore singleType lock (scalar scalarTypeWord8 0) Release
         return ()
   )
   -- Code after the loop
@@ -673,12 +671,11 @@ parCodeGenScan descending foldOrScan fun seed input index codeSeed codePre codeP
         else do
           _ <- Loop.while [] TupRunit
             (\_ -> do
-              idx <- instr $ Load Volatile idxPtr Nothing
+              idx <- instr $ AtomicLoad singleType idxPtr Acquire
               A.neq singleType idx (envsTileIndex envs)
             )
             (\_ -> return OP_Unit)
             OP_Unit
-          _ <- instr' $ LLVM.Fence (CrossThread, Acquire)
           return ()
 
         local <- tupleLoad tp accumVar
@@ -720,9 +717,8 @@ parCodeGenScan descending foldOrScan fun seed input index codeSeed codePre codeP
               app2 (llvmOfFun2 (compileArrayInstrEnvs envs) fun) prefix local
         tupleStore tp valuePtrs new
 
-        _ <- instr' $ LLVM.Fence (CrossThread, Release)
         OP_Int nextIdx <- A.add numType (envsTileIndex envs) (A.liftInt 1)
-        _ <- instr' $ Store Volatile idxPtr nextIdx Nothing
+        _ <- instr' $ AtomicStore singleType idxPtr nextIdx Release
         return ()
   )
   (\_ _ _ -> return ())

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen.hs
@@ -180,7 +180,12 @@ codegen name env cluster args
             -- here.
             bindLocals 0 envs' >>=
             bindLocalsInTile (\_ -> not $ null $ ptOtherLoops tileLoops) 1 tileSize
-          workassistLoop workassistIndex threadIndex threadCount tileCount $ \seqMode tileIdx' -> do
+          -- TODO: Set maxClaim based on:
+          -- * If the kernel contains scans, then 1.
+          -- * If the kernel contains non-commutative folds, then a small number between 2 and 8 (only possible after implementing folds based on interleaved scans)
+          -- * Otherwise, a high number like 1024. In this case, the kernel contains commutative folds which do not require a specific order.
+          let maxClaim = 1
+          workassistLoop workassistIndex workPerThread maxClaim threadIndex threadCount tileCount $ \seqMode tileIdx' -> do
             tileIdx <- instr' $ BitCast scalarType tileIdx'
             (_, lower, upper, _) <- tileRange (isDescending direction) (op TypeInt size) (integral TypeInt tileSize) tileCount' tileIdx
 
@@ -302,7 +307,7 @@ codegen name env cluster args
             if parallelDepth /= rank shr then []
             else {- if hasPermute then -} [Loop.LoopInterleave]
             -- else [Loop.LoopVectorize]
-      workassistChunked ann parallelShr workassistIndex threadIndex threadCount tileSize parSizes $ \idx -> do
+      workassistChunked ann parallelShr workassistIndex workPerThread 1024 threadIndex threadCount tileSize parSizes $ \idx -> do
         let envs' = envs{
             envsLoopDepth = parallelDepth,
             envsIdx =
@@ -316,7 +321,7 @@ codegen name env cluster args
 
       pure 0
   where
-    (argTp, extractEnv, workassistIndex, threadIndex {- or flag -}, threadCount, kernelMem', gamma) = bindHeaderEnv env
+    (argTp, extractEnv, workassistIndex, workPerThread, threadIndex {- or flag -}, threadCount, kernelMem', gamma) = bindHeaderEnv env
 
     isDescending :: LoopDirection Int -> Bool
     isDescending LoopDescending = True

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Base.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Base.hs
@@ -30,6 +30,7 @@ import Data.Primitive.Vec
 import LLVM.AST.Type.Representation
 import LLVM.AST.Type.Downcast
 import LLVM.AST.Type.Instruction
+import LLVM.AST.Type.Instruction.Volatile
 import LLVM.AST.Type.Operand
 
 import Data.String
@@ -40,15 +41,17 @@ import qualified Data.ByteString.Short.Char8                        as S8
 --  * continuation: ptr, u32 (program, location)
 --  * active_threads: u32,
 --  * work_index: u64,
+--  * work_per_thread: ptr (to array of u64),
 --  * tracy_srcloc: ptr,
 --  * In the future, perhaps also store a work_size: u32
 -- We store the work function as a pointer to a struct, as that makes it easy
 -- to separate pointers to a kernel from pointers to buffers, when compiling
 -- a schedule.
-type Header = (((((Ptr (Struct Int8), Ptr Int8), Word32), Word32), Word64), Ptr TracySrcloc)
+type Header = ((((((Ptr (Struct Int8), Ptr Int8), Word32), Word32), Word64), Ptr Word64), Ptr TracySrcloc)
 
 headerType :: TupR PrimType Header
 headerType = TupRsingle (PtrPrimType (StructPrimType False $ TupRsingle primType) defaultAddrSpace)
+  `TupRpair` TupRsingle primType
   `TupRpair` TupRsingle primType
   `TupRpair` TupRsingle primType
   `TupRpair` TupRsingle primType
@@ -72,6 +75,7 @@ bindHeaderEnv
   -> ( PrimType (Ptr (Struct ((Header, Struct (MarshalEnv env)), SizedArray Word)))
      , CodeGen Native ()
      , Operand (Ptr Word64) -- Pointer to work index
+     , Operand (Ptr Word64) -- work_per_thread
      , Operand Word32 -- First work index index
      , Operand Word32 -- Maximum number of threads (currently always the total number of worker threads of the system)
      , Operand (Ptr (SizedArray Word))
@@ -80,11 +84,14 @@ bindHeaderEnv
 bindHeaderEnv env =
   ( argTp
   , do
-      instr_ $ downcast $ nameIndex := GetElementPtr (gepStruct primType arg $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      instr_ $ downcast $ nameIndex := GetElementPtr (gepStruct primType arg $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      workPerThreadPtr <- instr' $ GetElementPtr (gepStruct primType arg $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      instr_ $ downcast $ nameWorkPerThread := Load NonVolatile workPerThreadPtr Nothing
       instr_ $ downcast $ "env" := GetElementPtr (gepStruct envTp arg $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       instr_ $ downcast $ nameKernelMemory := GetElementPtr (gepStruct kernelMemTp arg $ TupleIdxRight TupleIdxSelf)
       extractEnv
   , LocalReference (PrimType $ PtrPrimType (ScalarPrimType scalarType) defaultAddrSpace) nameIndex
+  , LocalReference (PrimType $ PtrPrimType (ScalarPrimType scalarType) defaultAddrSpace) nameWorkPerThread
   , LocalReference type' nameThreadIndex
   , LocalReference type' nameThreadCount
   , LocalReference (PrimType $ PtrPrimType kernelMemTp defaultAddrSpace) nameKernelMemory
@@ -98,6 +105,7 @@ bindHeaderEnv env =
     (envTp, extractEnv, gamma) = bindEnvFromStruct env
 
     nameIndex = "workassist.index"
+    nameWorkPerThread = "work_per_thread"
     nameThreadIndex = "thread.index"
     nameThreadCount = "thread.count"
     nameKernelMemory = "kernel_memory"

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Base.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Base.hs
@@ -45,7 +45,7 @@ import qualified Data.ByteString.Short.Char8                        as S8
 -- We store the work function as a pointer to a struct, as that makes it easy
 -- to separate pointers to a kernel from pointers to buffers, when compiling
 -- a schedule.
-type Header = ((((((Ptr (Struct Int8)), Ptr Int8), Word32), Word32), Word64), Ptr TracySrcloc)
+type Header = (((((Ptr (Struct Int8), Ptr Int8), Word32), Word32), Word64), Ptr TracySrcloc)
 
 headerType :: TupR PrimType Header
 headerType = TupRsingle (PtrPrimType (StructPrimType False $ TupRsingle primType) defaultAddrSpace)
@@ -60,8 +60,10 @@ type KernelType env
   = Ptr (Struct ((Header, Struct (MarshalEnv env)), SizedArray Word))
   -- Ptr to the locks array (for any permutes)
   -> Ptr Word8
-  -- first_index, or a magic value for single-threaded initialization or finalization
-  -> Word64
+  -- thread_index, or a magic value for single-threaded initialization or finalization
+  -> Word32
+  -- max_thread_count
+  -> Word32
   -- Only in initialization, this function returns whether the kernel should run sequentially or in parallel
   -> Word8
 
@@ -70,7 +72,8 @@ bindHeaderEnv
   -> ( PrimType (Ptr (Struct ((Header, Struct (MarshalEnv env)), SizedArray Word)))
      , CodeGen Native ()
      , Operand (Ptr Word64) -- Pointer to work index
-     , Operand (Word64) -- First work index index
+     , Operand Word32 -- First work index index
+     , Operand Word32 -- Maximum number of threads (currently always the total number of worker threads of the system)
      , Operand (Ptr (SizedArray Word))
      , Gamma env
      )
@@ -82,7 +85,8 @@ bindHeaderEnv env =
       instr_ $ downcast $ nameKernelMemory := GetElementPtr (gepStruct kernelMemTp arg $ TupleIdxRight TupleIdxSelf)
       extractEnv
   , LocalReference (PrimType $ PtrPrimType (ScalarPrimType scalarType) defaultAddrSpace) nameIndex
-  , LocalReference type' nameFirstIndex
+  , LocalReference type' nameThreadIndex
+  , LocalReference type' nameThreadCount
   , LocalReference (PrimType $ PtrPrimType kernelMemTp defaultAddrSpace) nameKernelMemory
   , gamma
   )
@@ -94,7 +98,8 @@ bindHeaderEnv env =
     (envTp, extractEnv, gamma) = bindEnvFromStruct env
 
     nameIndex = "workassist.index"
-    nameFirstIndex = "workassist.first_index"
+    nameThreadIndex = "thread.index"
+    nameThreadCount = "thread.count"
     nameKernelMemory = "kernel_memory"
 
     kernelMemTp :: PrimType (SizedArray Word)

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -32,6 +32,7 @@ import qualified Data.Array.Accelerate.LLVM.CodeGen.Loop            as Loop
 
 import Data.Array.Accelerate.LLVM.Native.Target                     ( Native )
 
+import LLVM.AST.Type.Downcast
 import LLVM.AST.Type.Representation
 import LLVM.AST.Type.Operand
 import LLVM.AST.Type.Instruction
@@ -39,6 +40,7 @@ import LLVM.AST.Type.Instruction.Atomic
 import LLVM.AST.Type.Instruction.Volatile
 import LLVM.AST.Type.Constant
 import qualified LLVM.AST.Type.Instruction.RMW as RMW
+import qualified LLVM.AST.Type.Instruction.Compare as Compare
 import Control.Monad.Trans
 import Control.Monad.State
 import Data.Array.Accelerate.LLVM.CodeGen.Base
@@ -181,58 +183,60 @@ iterFromTo tp start end seed body =
 
 workassistLoop
     :: Operand (Ptr Word64)                 -- index into work
-    -> Operand Word64                       -- index of the first block to work on
+    -> Operand Word32                       -- thread index
+    -> Operand Word32                       -- maximum number of threads
     -> Operand Word64                       -- size of total work
     -> (Operand Bool -> Operand Word64 -> CodeGen Native ())
     -> CodeGen Native ()
-workassistLoop counter firstIndex size doWork = do
+workassistLoop counter threadIndex threadCount size doWork = do
   entry    <- getBlock
+  claim    <- newBlock "workassist.loop.claim"
   work     <- newBlock "workassist.loop.work"
   claimed  <- newBlock "workassist.all.claimed"
   exit     <- newBlock "workassist.exit"
-  finished <- newBlock "workassist.finished"
 
-  initialCondition <- lt singleType (OP_Word64 firstIndex) (OP_Word64 size)
-  initialSeq <- eq singleType (OP_Word64 firstIndex) (liftWord64 0)
-  _ <- cbr initialCondition work exit
-
-  _ <- setBlock work
-  let indexName = "block_index"
+  let index = LocalReference (type' @Word64) "block_index"
   -- Whether the thread should operate in the single threaded mode of
   -- zero-overhead parallel scans.
-  let seqName = "sequential_mode"
-  let seqMode = LocalReference type' seqName
-  let index = LocalReference type' indexName
+  let seqMode = LocalReference (type' @Bool) "sequential_mode"
+  -- Expected next block index, if we continue in sequential mode
+  let nextIfSeqName = "next_block_if_seq"
+  let nextIfSeq = LocalReference type' nextIfSeqName
 
+  _ <- br claim
+
+  _ <- setBlock claim
+  instr_ $ downcast $ "block_index" := AtomicRMW numType NonVolatile RMW.Add counter (integral TypeWord64 1) (CrossThread, Monotonic)
+
+  condition <- lt singleType (OP_Word64 index) (OP_Word64 size)
+  _ <- cbr condition work exit
+
+  _ <- setBlock work
+
+  instr_ $ downcast $ "sequential_mode" := Cmp singleType Compare.EQ index nextIfSeq
   doWork seqMode index
 
-  nextIndex <- Loop.atomicAdd Monotonic counter (integral TypeWord64 1)
-  condition <- lt singleType (OP_Word64 nextIndex) (OP_Word64 size)
-  indexPlusOne <- add numType (OP_Word64 index) (liftWord64 1)
-  nextSeq' <- eq singleType indexPlusOne (OP_Word64 nextIndex)
-  -- Continue in sequential mode if the newly claimed block directly follows
-  -- the previous block, and we were still in the sequential mode.
-  nextSeq <- land nextSeq' (OP_Bool seqMode)
+  nextNextIfSeq <- add numType (OP_Word64 nextIfSeq) (OP_Word64 $ integral TypeWord64 1)
+  OP_Word64 nextNextIfSeq' <- select (TupRsingle scalarTypeWord64) (OP_Bool seqMode) nextNextIfSeq (OP_Word64 $ integral TypeWord64 0)
+
+  _ <- br claim
 
   -- Append the phi node to the start of the 'work' block.
   -- We can only do this now, as we need to have 'nextIndex', and know the
   -- exit block of 'doWork'.
   currentBlock <- getBlock
-  phi1 work indexName [(firstIndex, entry), (nextIndex, currentBlock)]
-  phi1 work seqName [(op BoolPrimType initialSeq, entry), (op BoolPrimType nextSeq, currentBlock)]
-
-  cbr condition work exit
+  phi1 claim nextIfSeqName [(integral TypeWord64 0, entry), (nextNextIfSeq', currentBlock)]
 
   setBlock exit
   retval_ $ scalar (scalarType @Word8) 0
 
-workassistChunked :: [Loop.LoopAnnotation] -> ShapeR sh -> Operand (Ptr Word64) -> Operand Word64 -> sh -> Operands sh -> (Operands sh -> CodeGen Native ()) -> CodeGen Native ()
-workassistChunked ann shr counter firstIndex chunkSz' sh doWork = do
+workassistChunked :: [Loop.LoopAnnotation] -> ShapeR sh -> Operand (Ptr Word64) -> Operand Word32 -> Operand Word32 -> sh -> Operands sh -> (Operands sh -> CodeGen Native ()) -> CodeGen Native ()
+workassistChunked ann shr counter threadIndex threadCount chunkSz' sh doWork = do
   let chunkSz = A.lift (shapeType shr) chunkSz'
   chunkCounts <- chunkCount shr sh chunkSz
   chunkCnt <- shapeSize shr chunkCounts
   chunkCnt' :: Operand Word64 <- instr' $ BitCast scalarType $ op TypeInt chunkCnt
-  workassistLoop counter firstIndex chunkCnt' $ \_ chunkLinearIndex -> do
+  workassistLoop counter threadIndex threadCount chunkCnt' $ \_ chunkLinearIndex -> do
     chunkLinearIndex' <- instr' $ BitCast scalarType chunkLinearIndex
     chunkIndex <- indexOfInt shr chunkCounts (OP_Int chunkLinearIndex')
     start <- chunkStart shr chunkSz chunkIndex

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -210,6 +210,9 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
   -- Expected next block index, if we continue in sequential mode
   let nextIfSeqName = "next_block_if_seq"
   let nextIfSeq = LocalReference type' nextIfSeqName
+  -- Estimate of the value in counter. This must be an underapproximation of
+  -- counter.
+  counterEstimate <- hoistAlloca $ primType @Word64
 
   _ <- br claim
 
@@ -230,6 +233,9 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
     claimStealGo <- newBlock "workassist.loop.claim.steal.go"
     claimStealSuccess <- newBlock "workassist.loop.claim.steal.success"
     claimStealFail <- newBlock "workassist.loop.claim.steal.fail"
+
+    initialCounter <- instr' $ AtomicLoad singleType counter Monotonic
+    _ <- instr' $ Store NonVolatile counterEstimate initialCounter Nothing
 
     -- The index from which we will next try to claim new work
     nextClaimThreadIdx <- hoistAlloca $ primType @Word32
@@ -288,7 +294,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       -- In case this happens, other threads can still steal those tiles back,
       -- and we can thus still balance the work (although with slightly more
       -- overhead).
-      currentCounter <- instr' $ AtomicLoad singleType counter Monotonic
+      currentCounter <- instr' $ Load NonVolatile counterEstimate Nothing
       check <- A.lt singleType (OP_Word64 currentCounter) (OP_Word64 size)
       _ <- cbr check claimGlobalGo claimSteal
 
@@ -304,8 +310,8 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       OP_Word64 maxThreadsMul2 <- A.fromIntegral integralType numType (OP_Word32 maxThreads) >>= A.mul numType (A.liftWord64 2)
       -- Use 'remaining / (maxThreads * 2)' as initial heuristic
       count1 <- A.quot TypeWord64 (OP_Word64 currentRemaining) (OP_Word64 maxThreadsMul2)
-      -- Claim at least 16 tiles
-      count2 <- A.max singleType count1 (A.liftWord64 2)
+      -- Claim at least 8 tiles
+      count2 <- A.max singleType count1 (A.liftWord64 8)
       -- Claim at most maxClaim tiles
       OP_Word64 count3 <- A.min singleType count2 (A.liftWord64 maxClaim)
 
@@ -319,6 +325,8 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
 
       -- Increment the global counter by count3
       index <- instr' $ AtomicRMW numType NonVolatile RMW.Add counter count3 (CrossThread, Monotonic)
+      OP_Word64 newCounter <- A.add numType (OP_Word64 index) (OP_Word64 count3)
+      _ <- instr' $ Store NonVolatile counterEstimate newCounter Nothing
 
       success <- A.lt singleType (OP_Word64 index) (OP_Word64 size)
 
@@ -343,12 +351,17 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
     -- 3. Otherwise, steal from other thread
     indexSteal <- do
       _ <- setBlock claimSteal
+      _ <- instr' $ Store NonVolatile counterEstimate size Nothing
+
       -- Unmark that we will claim something
       _ <- instr' $ AtomicStore singleType workPerThreadSelf (integral TypeWord64 0) Monotonic
       single <- A.eq singleType (OP_Word32 maxThreads) $ A.liftWord32 1
-      -- TODO: Set inc to:
-      -- int16_t inc = (thread_idx % 2 == 0) ? 1 : (thread_count - 1);
-      inc <- return $ A.liftWord32 1
+      inc <- do
+        -- (threadIdx % 2 == 0) ? 1 : thread_count - 1
+        even <- A.band TypeWord32 (OP_Word32 threadIndex) (A.liftWord32 1) >>= A.eq singleType (A.liftWord32 0)
+        let whenEven = A.liftWord32 1
+        whenOdd <- A.sub numType (OP_Word32 maxThreads) (A.liftWord32 1)
+        A.select (TupRsingle scalarType) even whenEven whenOdd
       -- totalAttempts = (maxThreads - 1) * 2
       -- Subtract one, as a thread won't steal from itself.
       OP_Word32 totalAttempts <- A.sub numType (OP_Word32 maxThreads) (A.liftWord32 1) >>= A.mul numType (A.liftWord32 2)
@@ -495,10 +508,10 @@ chunkSizeOne (ShapeRsnoc sh) = (chunkSizeOne sh, 1)
 
 chunkSize :: ShapeR sh -> sh
 chunkSize ShapeRz = ()
-chunkSize (ShapeRsnoc ShapeRz) = ((), 1024)
-chunkSize (ShapeRsnoc (ShapeRsnoc ShapeRz)) = (((), 32), 32)
-chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc ShapeRz))) = ((((), 8), 8), 16)
-chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc sh)))) = ((((chunkSizeOne sh, 4), 4), 8), 8)
+chunkSize (ShapeRsnoc ShapeRz) = ((), 512)
+chunkSize (ShapeRsnoc (ShapeRsnoc ShapeRz)) = (((), 16), 32)
+chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc ShapeRz))) = ((((), 4), 8), 16)
+chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc sh)))) = ((((chunkSizeOne sh, 4), 4), 4), 8)
 
 chunkCount :: ShapeR sh -> Operands sh -> Operands sh -> CodeGen Native (Operands sh)
 chunkCount ShapeRz OP_Unit OP_Unit = return OP_Unit

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -21,7 +21,6 @@ module Data.Array.Accelerate.LLVM.Native.CodeGen.Loop
 import Data.Array.Accelerate.Representation.Type
 import Data.Array.Accelerate.Representation.Shape                   hiding ( eq )
 
-import Data.Array.Accelerate.LLVM.CodeGen.Arithmetic                hiding ( lift )
 import qualified Data.Array.Accelerate.LLVM.CodeGen.Arithmetic      as A
 import Data.Array.Accelerate.LLVM.CodeGen.Constant
 import Data.Array.Accelerate.LLVM.CodeGen.Exp
@@ -39,12 +38,15 @@ import LLVM.AST.Type.Instruction
 import LLVM.AST.Type.Instruction.Atomic
 import LLVM.AST.Type.Instruction.Volatile
 import LLVM.AST.Type.Constant
+import LLVM.AST.Type.GetElementPtr
 import qualified LLVM.AST.Type.Instruction.RMW as RMW
 import qualified LLVM.AST.Type.Instruction.Compare as Compare
+import LLVM.AST.Type.Name
+import Data.Array.Accelerate.LLVM.CodeGen.Base
+
 import Control.Monad.Trans
 import Control.Monad.State
-import Data.Array.Accelerate.LLVM.CodeGen.Base
-import LLVM.AST.Type.Name
+import Data.Bits
 
 -- | A standard 'for' loop, that steps from the start to end index executing the
 -- given function at each index.
@@ -55,7 +57,7 @@ imapFromTo
     -> (Operands Int -> CodeGen Native ())            -- ^ apply at each index
     -> CodeGen Native ()
 imapFromTo start end body =
-  Loop.imapFromStepTo [] start (liftInt 1) end body
+  Loop.imapFromStepTo [] start (A.liftInt 1) end body
 
 
 -- | Generate a series of nested 'for' loops which iterate between the start and
@@ -83,7 +85,7 @@ imapNestFromTo annOuter annInner shr start end extent body =
 
     go (ShapeRsnoc shr') (OP_Pair ssh ssz) (OP_Pair esh esz) k
       = go shr' ssh esh
-      $ \sz      -> Loop.imapFromStepTo ann ssz (liftInt 1) esz
+      $ \sz      -> Loop.imapFromStepTo ann ssz (A.liftInt 1) esz
       $ \i       -> k (OP_Pair sz i)
       where
         ann = case shr' of
@@ -179,16 +181,22 @@ iterFromTo
     -> (Operands Int -> Operands a -> CodeGen Native (Operands a))    -- ^ apply at each index
     -> CodeGen Native (Operands a)
 iterFromTo tp start end seed body =
-  Loop.iterFromStepTo [] tp start (liftInt 1) end seed body
+  Loop.iterFromStepTo [] tp start (A.liftInt 1) end seed body
+
+-- Should match with ACCELERATE_WORK_PER_THREAD_STRIDE in types.h
+workPerThreadStride :: Word32
+workPerThreadStride = 8
 
 workassistLoop
     :: Operand (Ptr Word64)                 -- index into work
+    -> Operand (Ptr Word64)                 -- work_per_thread
+    -> Word64                               -- maximum number of tiles to claim at once. When zero, this performs self scheduling, otherwise it performs data-parallel work stealing.
     -> Operand Word32                       -- thread index
     -> Operand Word32                       -- maximum number of threads
     -> Operand Word64                       -- size of total work
     -> (Operand Bool -> Operand Word64 -> CodeGen Native ())
     -> CodeGen Native ()
-workassistLoop counter threadIndex threadCount size doWork = do
+workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork = do
   entry    <- getBlock
   claim    <- newBlock "workassist.loop.claim"
   work     <- newBlock "workassist.loop.work"
@@ -206,18 +214,144 @@ workassistLoop counter threadIndex threadCount size doWork = do
   _ <- br claim
 
   _ <- setBlock claim
-  instr_ $ downcast $ "block_index" := AtomicRMW numType NonVolatile RMW.Add counter (integral TypeWord64 1) (CrossThread, Monotonic)
+  if maxClaim == 1 then do
+    instr_ $ downcast $ "block_index" := AtomicRMW numType NonVolatile RMW.Add counter (integral TypeWord64 1) (CrossThread, Monotonic)
+    condition <- A.lt singleType (OP_Word64 index) (OP_Word64 size)
+    _ <- cbr condition work exit
 
-  condition <- lt singleType (OP_Word64 index) (OP_Word64 size)
-  _ <- cbr condition work exit
+    _ <- setBlock work
+    return ()
+  else do
+    claimGlobal <- newBlock "workassist.loop.claim.global"
+    claimGlobalGo <- newBlock "workassist.loop.claim.global.go"
+    claimGlobalSuccess <- newBlock "workassist.loop.claim.global.success"
+    claimSteal <- newBlock "workassist.loop.claim.steal"
 
-  _ <- setBlock work
+    -- In workPerThread, each thread stores the range of work it has claimed,
+    -- but has not started working on.
+    -- We represent this range as a single Word64 by packing the start and
+    -- size of the range. The 48 most significant bits are used for the
+    -- start tile index, and the 16 least significant store the size.
+    -- The size is treated as a *signed* integer, and may become negative
+    -- when multiple threads concurrently claim (steal) work from this entry.
+    -- We limit the size of a steal, to ensure the size won't wrap around
+    -- (underflow) during many concurrent steals.
+    --
+    -- Scheduling works via three sub-procedures:
+    -- 1. Claiming from our own workPerThread entry.
+    -- 2. If that fails, claim work from the global counter, add that to our
+    --    entry in workPerThread.
+    -- 3. If that also fails, steal work from other threads by updating their
+    --    workPerThread entry.
+
+    OP_Word32 threadIndexMulStride <- A.mul numType (OP_Word32 threadIndex) $ OP_Word32 $ integral TypeWord32 workPerThreadStride
+    workPerThreadSelf <- instr' $ GetElementPtr $ GEP1 workPerThread threadIndexMulStride
+
+    -- 1. Claim from our own workPerThread entry.
+    indexLocal <- do
+      -- Increment the start index of the range by one,
+      -- and decrement the size by one,
+      -- to claim the first item (tile) of the range.
+      let increment = (1 `shiftL` 16) - 1
+      packed <- instr' $ AtomicRMW numType NonVolatile RMW.Add workPerThreadSelf (integral TypeWord64 increment) (CrossThread, Monotonic)
+
+      -- Unpack the packed value
+      OP_Word64 start <- A.shiftR TypeWord64 (OP_Word64 packed) (A.liftInt 16)
+      let sizeMask = (1 `shiftL` 16) - 1
+      size' <- A.band TypeWord64 (OP_Word64 packed) (A.liftWord64 sizeMask)
+      -- Convert to signed 16 bit number
+      size16 <- A.fromIntegral TypeWord64 numType size'
+      OP_Int64 size <- A.fromIntegral TypeInt16 numType size16
+
+      success <- A.gt singleType (OP_Int64 size) $ A.liftInt64 0
+
+      _ <- cbr success work claimGlobal
+      return start
+
+    -- 2. Otherwise, claim from global counter
+    indexGlobal <- do
+      _ <- setBlock claimGlobal
+      -- First, use a heuristic to compute how many tiles we will claim from
+      -- the global counter. This is based on the current number of remaining
+      -- tiles. There is a risk for a race condition here, as there is time
+      -- between computing the tile size and doing the actual fetch-and-add.
+      -- This race condition is not a correctness problem however; it will
+      -- only impact performance when we claim too many tiles.
+      -- In case this happens, other threads can still steal those tiles back,
+      -- and we can thus still balance the work (although with slightly more
+      -- overhead).
+      -- TODO: Change volatile load to atomic load
+      currentCounter <- instr' $ Load Volatile counter Nothing
+      check <- A.lt singleType (OP_Word64 currentCounter) (OP_Word64 size)
+      _ <- cbr check claimGlobalGo claimSteal
+
+      -- TODO: If maxClaim is small (<= 32) we could drop this heuristic, and
+      -- always claim maxClaim tiles. We could then also drop the early out
+      -- via 'check'.
+      -- The following code somewhat assumes that maxClaim is more than 16.
+      -- (It will work, but the heuristic is essentially doing nothing
+      -- and always claiming maxClaim tiles if maxClaim <= 16).
+
+      _ <- setBlock claimGlobalGo
+      OP_Word64 currentRemaining <- A.sub numType (OP_Word64 size) (OP_Word64 currentCounter)
+      OP_Word64 maxThreadsMul2 <- A.fromIntegral integralType numType (OP_Word32 maxThreads) >>= A.mul numType (A.liftWord64 2)
+      -- Use 'remaining / (maxThreads * 2)' as initial heuristic
+      count1 <- A.quot TypeWord64 (OP_Word64 currentRemaining) (OP_Word64 maxThreadsMul2)
+      -- Claim at least 16 tiles
+      count2 <- A.max singleType count1 (A.liftWord64 2)
+      -- Claim at most maxClaim tiles
+      OP_Word64 count3 <- A.min singleType count2 (A.liftWord64 maxClaim)
+
+      -- TODO: Maybe we should announce here that we will claim something from
+      -- the global counter. This informs other threads during stealing, that
+      -- more stealable work might become available soon, and that they should
+      -- not exit yet.
+      -- We can announce this by storing a magic value in workPerThreadSelf.
+      -- This magic value will be overwritten already by the newly claimed
+      -- work. However, if there is no more work to be claimed, we need to
+      -- explicitely remove this announcement.
+
+      -- Increment the global counter by count3
+      index <- instr' $ AtomicRMW numType NonVolatile RMW.Add counter count3 (CrossThread, Monotonic)
+
+      success <- A.lt singleType (OP_Word64 index) (OP_Word64 size)
+
+      _ <- cbr success claimGlobalSuccess claimSteal
+
+      _ <- setBlock claimGlobalSuccess
+      -- Success, we claimed some blocks from the global counter.
+      -- Check how many we actually claimed (since we may have claimed fewer
+      -- tiles if those were the last tiles).
+      maxClaimed <- A.sub numType (OP_Word64 size) (OP_Word64 index)
+      claimed <- A.min singleType (OP_Word64 count3) maxClaimed
+      claimedSubOne <- A.sub numType claimed $ A.liftWord64 1
+      _ <- br work
+
+      indexPlusOne <- A.add numType (OP_Word64 index) $ A.liftWord64 1
+      -- Pack indexPlusOne and claimedSubOne into a word, and store that in workPerThread
+      OP_Word64 packed <- A.shiftL TypeWord64 indexPlusOne (A.liftInt 16) >>= A.bor TypeWord64 claimedSubOne
+      -- TODO: Change volatile store to atomic store
+      _ <- instr' $ Store Volatile workPerThreadSelf packed Nothing
+
+      return index
+
+    -- 3. Otherwise, steal from other thread
+    indexSteal <- do
+      -- TODO: Steal work from other threads
+      _ <- setBlock claimSteal
+      _ <- br exit
+      return $ integral TypeWord64 0xFFFFFFFF -- TODO
+
+    -- Add phi node to the work block, so it will choose the correct index
+    _ <- setBlock work
+    _ <- phi1 work "block_index" [(indexLocal, claim), (indexGlobal, claimGlobalSuccess) {-, (indexSteal, claimSteal TODO: Is this the right block? (We problably add if-then-elses to stealing...)) -}]
+    return ()
 
   instr_ $ downcast $ "sequential_mode" := Cmp singleType Compare.EQ index nextIfSeq
   doWork seqMode index
 
-  nextNextIfSeq <- add numType (OP_Word64 nextIfSeq) (OP_Word64 $ integral TypeWord64 1)
-  OP_Word64 nextNextIfSeq' <- select (TupRsingle scalarTypeWord64) (OP_Bool seqMode) nextNextIfSeq (OP_Word64 $ integral TypeWord64 0)
+  nextNextIfSeq <- A.add numType (OP_Word64 nextIfSeq) (OP_Word64 $ integral TypeWord64 1)
+  OP_Word64 nextNextIfSeq' <- A.select (TupRsingle scalarTypeWord64) (OP_Bool seqMode) nextNextIfSeq (OP_Word64 $ integral TypeWord64 0)
 
   _ <- br claim
 
@@ -225,18 +359,18 @@ workassistLoop counter threadIndex threadCount size doWork = do
   -- We can only do this now, as we need to have 'nextIndex', and know the
   -- exit block of 'doWork'.
   currentBlock <- getBlock
-  phi1 claim nextIfSeqName [(integral TypeWord64 0, entry), (nextNextIfSeq', currentBlock)]
+  _ <- phi1 claim nextIfSeqName [(integral TypeWord64 0, entry), (nextNextIfSeq', currentBlock)]
 
   setBlock exit
   retval_ $ scalar (scalarType @Word8) 0
 
-workassistChunked :: [Loop.LoopAnnotation] -> ShapeR sh -> Operand (Ptr Word64) -> Operand Word32 -> Operand Word32 -> sh -> Operands sh -> (Operands sh -> CodeGen Native ()) -> CodeGen Native ()
-workassistChunked ann shr counter threadIndex threadCount chunkSz' sh doWork = do
+workassistChunked :: [Loop.LoopAnnotation] -> ShapeR sh -> Operand (Ptr Word64) -> Operand (Ptr Word64) -> Word64 -> Operand Word32 -> Operand Word32 -> sh -> Operands sh -> (Operands sh -> CodeGen Native ()) -> CodeGen Native ()
+workassistChunked ann shr counter workPerThread maxClaim threadIndex maxThreads chunkSz' sh doWork = do
   let chunkSz = A.lift (shapeType shr) chunkSz'
   chunkCounts <- chunkCount shr sh chunkSz
   chunkCnt <- shapeSize shr chunkCounts
   chunkCnt' :: Operand Word64 <- instr' $ BitCast scalarType $ op TypeInt chunkCnt
-  workassistLoop counter threadIndex threadCount chunkCnt' $ \_ chunkLinearIndex -> do
+  workassistLoop counter workPerThread maxClaim threadIndex maxThreads chunkCnt' $ \_ chunkLinearIndex -> do
     chunkLinearIndex' <- instr' $ BitCast scalarType chunkLinearIndex
     chunkIndex <- indexOfInt shr chunkCounts (OP_Int chunkLinearIndex')
     start <- chunkStart shr chunkSz chunkIndex
@@ -249,10 +383,10 @@ chunkSizeOne (ShapeRsnoc sh) = (chunkSizeOne sh, 1)
 
 chunkSize :: ShapeR sh -> sh
 chunkSize ShapeRz = ()
-chunkSize (ShapeRsnoc ShapeRz) = ((), 1024 * 8)
-chunkSize (ShapeRsnoc (ShapeRsnoc ShapeRz)) = (((), 64), 128)
-chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc ShapeRz))) = ((((), 8), 16), 64)
-chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc sh)))) = ((((chunkSizeOne sh, 4), 4), 8), 64)
+chunkSize (ShapeRsnoc ShapeRz) = ((), 1024)
+chunkSize (ShapeRsnoc (ShapeRsnoc ShapeRz)) = (((), 32), 32)
+chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc ShapeRz))) = ((((), 8), 8), 16)
+chunkSize (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc (ShapeRsnoc sh)))) = ((((chunkSizeOne sh, 4), 4), 8), 8)
 
 chunkCount :: ShapeR sh -> Operands sh -> Operands sh -> CodeGen Native (Operands sh)
 chunkCount ShapeRz OP_Unit OP_Unit = return OP_Unit
@@ -261,8 +395,8 @@ chunkCount (ShapeRsnoc shr) (OP_Pair sh sz) (OP_Pair chunkSh chunkSz) = do
   
   -- Compute ceil(sz / chunkSz), as
   -- (sz + chunkSz - 1) `quot` chunkSz
-  chunkszsub1 <- sub numType chunkSz $ liftInt 1
-  sz' <- add numType sz chunkszsub1
+  chunkszsub1 <- A.sub numType chunkSz $ A.liftInt 1
+  sz' <- A.add numType sz chunkszsub1
   count <- A.quot TypeInt sz' chunkSz
 
   return $ OP_Pair counts count
@@ -271,7 +405,7 @@ chunkStart :: ShapeR sh -> Operands sh -> Operands sh -> CodeGen Native (Operand
 chunkStart ShapeRz OP_Unit OP_Unit = return OP_Unit
 chunkStart (ShapeRsnoc shr) (OP_Pair chunkSh chunkSz) (OP_Pair sh sz) = do
   ixs <- chunkStart shr chunkSh sh
-  ix <- mul numType sz chunkSz
+  ix <- A.mul numType sz chunkSz
   return $ OP_Pair ixs ix
 
 chunkEnd
@@ -283,6 +417,6 @@ chunkEnd
 chunkEnd ShapeRz OP_Unit OP_Unit OP_Unit = return OP_Unit
 chunkEnd (ShapeRsnoc shr) (OP_Pair sh0 sz0) (OP_Pair sh1 sz1) (OP_Pair sh2 sz2) = do
   sh3 <- chunkEnd shr sh0 sh1 sh2
-  sz3 <- add numType sz2 sz1
+  sz3 <- A.add numType sz2 sz1
   sz3' <- A.min singleType sz3 sz0
   return $ OP_Pair sh3 sz3'

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -184,9 +184,39 @@ iterFromTo tp start end seed body =
   Loop.iterFromStepTo [] tp start (A.liftInt 1) end seed body
 
 -- Should match with ACCELERATE_WORK_PER_THREAD_STRIDE in types.h
+--
+-- Note that we could dynamically figure out the cache line size and base this
+-- stride on that, but that's probably not worth the complexity and maintance
+-- cost. If we change our mind, this is a possible implementation:
+-- https://github.com/ivogabe/accelerate-llvm/pull/4/changes#diff-02f146262b0961de9166aef529dab4eecccf091256d3a12a17c00588f4de8c09
+-- (get_cache_line_size in runtime.c)
 workPerThreadStride :: Word32
 workPerThreadStride = 8
 
+-- Generate code for a parallel loop. Any thread working on this parallel loop
+-- will execute this code, and claim work from a shared counter.
+-- When maxClaim is one, this will claim tiles one by one, via standard self
+-- scheduling.
+--
+-- When maxClaim is higher, it will claim multiple tiles at once. The number of
+-- tiles is chosen via a simple heuristic, and at most maxClaim. When all work
+-- is claimed, and threads become idle, they will try to steal tiles that have
+-- already been claimed by other threads, similar to work stealing for task
+-- parallelism. Instead of a queue per thread, the claimed work is stored in
+-- one 64-bit word, representing a range of tiles, to ensure a low scheduling
+-- overhead.
+--
+-- Setting maxClaim to 1 has the advantage that tiles are claimed in order, and
+-- generates the most simple code. Setting maxClaim higher often has better
+-- performance, due to two reasons:
+-- 1. Lower scheduling overhead because of lower contention on 'counter'.
+-- 2. More cache locality as threads work on a range of tiles.
+-- The first point was the primary goal during the design of a new scheduling
+-- algorithm. However during this research (as part of a master thesis, see
+-- https://studenttheses.uu.nl/items/d9017822-f192-4a71-a8c8-648ee5eedad9),
+-- we also saw large speedups due to improved cache locality.
+-- This work-stealing based data-parallel scheduler was implemented based on
+-- the findings of that thesis.
 workassistLoop
     :: Operand (Ptr Word64)                 -- index into work
     -> Operand (Ptr Word64)                 -- work_per_thread

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -309,14 +309,13 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       -- Claim at most maxClaim tiles
       OP_Word64 count3 <- A.min singleType count2 (A.liftWord64 maxClaim)
 
-      -- TODO: Maybe we should announce here that we will claim something from
-      -- the global counter. This informs other threads during stealing, that
-      -- more stealable work might become available soon, and that they should
-      -- not exit yet.
-      -- We can announce this by storing a magic value in workPerThreadSelf.
-      -- This magic value will be overwritten already by the newly claimed
-      -- work. However, if there is no more work to be claimed, we need to
-      -- explicitely remove this announcement.
+      -- Mark that we are about to claim something
+      -- A range where the start is 2^47+2^46, and the size is non-positive,
+      -- denotes that a thread is about to claim work. Since the size is
+      -- non-positive, other threads know that this thread has no work,
+      -- and those threads can then check the start index for 2^47+2^46.
+      let markAnnounce = (1 `shiftL` 63) + (1 `shiftL` 62)
+      _ <- instr' $ AtomicStore singleType workPerThreadSelf (integral TypeWord64 markAnnounce) Monotonic
 
       -- Increment the global counter by count3
       index <- instr' $ AtomicRMW numType NonVolatile RMW.Add counter count3 (CrossThread, Monotonic)
@@ -326,7 +325,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       _ <- cbr success claimGlobalSuccess claimSteal
 
       _ <- setBlock claimGlobalSuccess
-      -- Success, we claimed some blocks from the global counter.
+      -- Success, we claimed some tiles from the global counter.
       -- Check how many we actually claimed (since we may have claimed fewer
       -- tiles if those were the last tiles).
       maxClaimed <- A.sub numType (OP_Word64 size) (OP_Word64 index)
@@ -344,6 +343,8 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
     -- 3. Otherwise, steal from other thread
     indexSteal <- do
       _ <- setBlock claimSteal
+      -- Unmark that we will claim something
+      _ <- instr' $ AtomicStore singleType workPerThreadSelf (integral TypeWord64 0) Monotonic
       single <- A.eq singleType (OP_Word32 maxThreads) $ A.liftWord32 1
       -- TODO: Set inc to:
       -- int16_t inc = (thread_idx % 2 == 0) ? 1 : (thread_count - 1);
@@ -370,7 +371,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       otherWorkPtr <- instr' $ GetElementPtr $ GEP1 workPerThread otherIndexMulStride
       -- First perform an early check, before we perform an atomic fetch-and-add
       earlyPacked <- instr $ AtomicLoad singleType otherWorkPtr Monotonic
-      (_, earlySize) <- unpackWorkRange earlyPacked
+      (earlyStart, earlySize) <- unpackWorkRange earlyPacked
       canSteal <- A.gte singleType earlySize $ A.liftInt64 1
 
       _ <- cbr canSteal claimStealGo claimStealFail
@@ -398,7 +399,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       -- Compute the start index of the range we claimed
       currentEnd <- A.add numType currentStart currentSize'
       OP_Word64 claimedStart <- A.sub numType currentEnd claimedSize
-      -- Store claimed blocks (but one) in our own workPerThread entry
+      -- Store claimed tiles (but one) in our own workPerThread entry
       claimedStartPlusOne <- A.add numType (OP_Word64 claimedStart) $ A.liftWord64 1
       claimedSizeSubOne <- A.sub numType claimedSize $ A.liftWord64 1
       OP_Word64 selfPacked <- packWorkRange claimedStartPlusOne claimedSizeSubOne
@@ -406,6 +407,20 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       _ <- br work
 
       _ <- setBlock claimStealFail
+      failStart <- phi (TupRsingle scalarTypeWord64) [(earlyStart, claimStealLoop), (currentStart, claimStealGo)]
+      A.when (A.eq singleType failStart $ A.liftWord64 $ (1 `shiftL` 47) + (1 `shiftL` 46)) $ do
+        -- The other thread is about to claim something. This thread should
+        -- thus not exit yet, as we may be able to steal something of the
+        -- other thread in a bit. Reset 'remaining'. We should reset it to:
+        -- totalAttempts = (maxThreads - 1) * 2
+        -- Since stealAttempts will be lowered by one a few lines later,
+        -- we set it to (maxThreads - 1) * 2 + 1
+        --
+        -- Subtract one, as a thread won't steal from itself.
+        OP_Word32 totalAttemptsPlus1 <- A.sub numType (OP_Word32 maxThreads) (A.liftWord32 1) >>=
+          A.mul numType (A.liftWord32 2) >>= A.add numType (A.liftWord32 1)
+        _ <- instr' $ Store NonVolatile stealAttempts totalAttemptsPlus1 Nothing
+        return ()
       -- Update nextClaimThreadIdx
       OP_Word32 nextIndex <- do
         i <- A.add numType otherIndex inc
@@ -425,6 +440,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
 
     -- Add phi node to the work block, so it will choose the correct index
     _ <- setBlock work
+    -- TODO: Rename block_index to tile_index
     _ <- phi1 work "block_index" [(indexLocal, claim), (indexGlobal, claimGlobalSuccess), (indexSteal, claimStealSuccess)]
     return ()
 

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Loop.hs
@@ -226,6 +226,18 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
     claimGlobalGo <- newBlock "workassist.loop.claim.global.go"
     claimGlobalSuccess <- newBlock "workassist.loop.claim.global.success"
     claimSteal <- newBlock "workassist.loop.claim.steal"
+    claimStealLoop <- newBlock "workassist.loop.claim.steal.loop"
+    claimStealGo <- newBlock "workassist.loop.claim.steal.go"
+    claimStealSuccess <- newBlock "workassist.loop.claim.steal.success"
+    claimStealFail <- newBlock "workassist.loop.claim.steal.fail"
+
+    -- The index from which we will next try to claim new work
+    nextClaimThreadIdx <- hoistAlloca $ primType @Word32
+    instr' $ Store NonVolatile nextClaimThreadIdx threadIndex Nothing
+
+    -- The number of attempts left for stealing.
+    -- After this many failed attempts, a thread will exit.
+    stealAttempts <- hoistAlloca $ primType @Word32
 
     -- In workPerThread, each thread stores the range of work it has claimed,
     -- but has not started working on.
@@ -253,17 +265,11 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       -- and decrement the size by one,
       -- to claim the first item (tile) of the range.
       let increment = (1 `shiftL` 16) - 1
-      packed <- instr' $ AtomicRMW numType NonVolatile RMW.Add workPerThreadSelf (integral TypeWord64 increment) (CrossThread, Monotonic)
+      packed <- instr $ AtomicRMW numType NonVolatile RMW.Add workPerThreadSelf (integral TypeWord64 increment) (CrossThread, Monotonic)
 
-      -- Unpack the packed value
-      OP_Word64 start <- A.shiftR TypeWord64 (OP_Word64 packed) (A.liftInt 16)
-      let sizeMask = (1 `shiftL` 16) - 1
-      size' <- A.band TypeWord64 (OP_Word64 packed) (A.liftWord64 sizeMask)
-      -- Convert to signed 16 bit number
-      size16 <- A.fromIntegral TypeWord64 numType size'
-      OP_Int64 size <- A.fromIntegral TypeInt16 numType size16
+      (OP_Word64 start, rangeSize) <- unpackWorkRange packed
 
-      success <- A.gt singleType (OP_Int64 size) $ A.liftInt64 0
+      success <- A.gt singleType rangeSize $ A.liftInt64 0
 
       _ <- cbr success work claimGlobal
       return start
@@ -271,6 +277,8 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
     -- 2. Otherwise, claim from global counter
     indexGlobal <- do
       _ <- setBlock claimGlobal
+      _ <- instr' $ AtomicStore singleType workPerThreadSelf (integral TypeWord64 0) Monotonic
+
       -- First, use a heuristic to compute how many tiles we will claim from
       -- the global counter. This is based on the current number of remaining
       -- tiles. There is a risk for a race condition here, as there is time
@@ -280,8 +288,7 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
       -- In case this happens, other threads can still steal those tiles back,
       -- and we can thus still balance the work (although with slightly more
       -- overhead).
-      -- TODO: Change volatile load to atomic load
-      currentCounter <- instr' $ Load Volatile counter Nothing
+      currentCounter <- instr' $ AtomicLoad singleType counter Monotonic
       check <- A.lt singleType (OP_Word64 currentCounter) (OP_Word64 size)
       _ <- cbr check claimGlobalGo claimSteal
 
@@ -329,22 +336,96 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
 
       indexPlusOne <- A.add numType (OP_Word64 index) $ A.liftWord64 1
       -- Pack indexPlusOne and claimedSubOne into a word, and store that in workPerThread
-      OP_Word64 packed <- A.shiftL TypeWord64 indexPlusOne (A.liftInt 16) >>= A.bor TypeWord64 claimedSubOne
-      -- TODO: Change volatile store to atomic store
-      _ <- instr' $ Store Volatile workPerThreadSelf packed Nothing
+      OP_Word64 packed <- packWorkRange indexPlusOne claimedSubOne
+      _ <- instr' $ AtomicStore singleType workPerThreadSelf packed Monotonic
 
       return index
 
     -- 3. Otherwise, steal from other thread
     indexSteal <- do
-      -- TODO: Steal work from other threads
       _ <- setBlock claimSteal
-      _ <- br exit
-      return $ integral TypeWord64 0xFFFFFFFF -- TODO
+      single <- A.eq singleType (OP_Word32 maxThreads) $ A.liftWord32 1
+      -- TODO: Set inc to:
+      -- int16_t inc = (thread_idx % 2 == 0) ? 1 : (thread_count - 1);
+      inc <- return $ A.liftWord32 1
+      -- totalAttempts = (maxThreads - 1) * 2
+      -- Subtract one, as a thread won't steal from itself.
+      OP_Word32 totalAttempts <- A.sub numType (OP_Word32 maxThreads) (A.liftWord32 1) >>= A.mul numType (A.liftWord32 2)
+      _ <- instr' $ Store NonVolatile stealAttempts totalAttempts Nothing
+      cbr single exit claimStealLoop
+
+      _ <- setBlock claimStealLoop
+      otherIndex <- do
+        i <- instr $ Load NonVolatile nextClaimThreadIdx Nothing
+        -- If i equals threadIndex, increment it first
+        isSelf <- A.eq singleType i $ OP_Word32 threadIndex
+        iPlus <- A.add numType i inc
+        tooLarge <- A.gte singleType iPlus $ OP_Word32 maxThreads
+        iPlusSub <- A.sub numType iPlus $ OP_Word32 maxThreads
+        iPlus' <- A.select (TupRsingle scalarType) tooLarge iPlusSub iPlus
+        A.select (TupRsingle scalarType) isSelf iPlus' i
+
+      -- Check if we can steal here
+      OP_Word32 otherIndexMulStride <- A.mul numType otherIndex $ OP_Word32 $ integral TypeWord32 workPerThreadStride
+      otherWorkPtr <- instr' $ GetElementPtr $ GEP1 workPerThread otherIndexMulStride
+      -- First perform an early check, before we perform an atomic fetch-and-add
+      earlyPacked <- instr $ AtomicLoad singleType otherWorkPtr Monotonic
+      (_, earlySize) <- unpackWorkRange earlyPacked
+      canSteal <- A.gte singleType earlySize $ A.liftInt64 1
+
+      _ <- cbr canSteal claimStealGo claimStealFail
+
+      _ <- setBlock claimStealGo
+      -- Decide how many tiles we want to steal using a simple heuristic:
+      -- min(4, ceil(earlySize / 3))
+      OP_Word64 claimSize <- do
+        -- b = ceil(earlySize / 3)
+        a <- A.add numType earlySize $ A.liftInt64 2
+        b <- A.quot TypeInt64 a $ A.liftInt64 3
+        -- Claim at most 4 tiles
+        c <- A.min singleType b $ A.liftInt64 4
+        A.fromIntegral TypeInt64 numType c
+      -- Steal tiles by atomically updating otherWorkPtr
+      packed <- instr $ AtomicRMW numType NonVolatile RMW.Sub otherWorkPtr claimSize (CrossThread, Monotonic)
+      (currentStart, currentSize) <- unpackWorkRange packed
+      success <- A.gte singleType currentSize $ A.liftInt64 1
+      _ <- cbr success claimStealSuccess claimStealFail
+
+      _ <- setBlock claimStealSuccess
+      currentSize' <- A.fromIntegral TypeInt64 (numType @Word64) currentSize
+      -- Compute the number of tiles we claimed
+      claimedSize <- A.min singleType (OP_Word64 claimSize) currentSize'
+      -- Compute the start index of the range we claimed
+      currentEnd <- A.add numType currentStart currentSize'
+      OP_Word64 claimedStart <- A.sub numType currentEnd claimedSize
+      -- Store claimed blocks (but one) in our own workPerThread entry
+      claimedStartPlusOne <- A.add numType (OP_Word64 claimedStart) $ A.liftWord64 1
+      claimedSizeSubOne <- A.sub numType claimedSize $ A.liftWord64 1
+      OP_Word64 selfPacked <- packWorkRange claimedStartPlusOne claimedSizeSubOne
+      _ <- instr' $ Store NonVolatile workPerThreadSelf selfPacked Nothing
+      _ <- br work
+
+      _ <- setBlock claimStealFail
+      -- Update nextClaimThreadIdx
+      OP_Word32 nextIndex <- do
+        i <- A.add numType otherIndex inc
+        tooLarge <- A.gte singleType i $ OP_Word32 maxThreads
+        iSub <- A.sub numType i $ OP_Word32 maxThreads
+        A.select (TupRsingle scalarType) tooLarge iSub i
+      _ <- instr' $ Store NonVolatile nextClaimThreadIdx nextIndex Nothing
+
+      remaining <- instr $ Load NonVolatile stealAttempts Nothing
+      OP_Word32 remaining' <- A.sub numType remaining (A.liftWord32 1)
+      _ <- instr' $ Store NonVolatile stealAttempts remaining' Nothing
+      shouldExit <- A.eq singleType remaining $ A.liftWord32 0
+
+      _ <- cbr shouldExit exit claimStealLoop
+
+      return claimedStart
 
     -- Add phi node to the work block, so it will choose the correct index
     _ <- setBlock work
-    _ <- phi1 work "block_index" [(indexLocal, claim), (indexGlobal, claimGlobalSuccess) {-, (indexSteal, claimSteal TODO: Is this the right block? (We problably add if-then-elses to stealing...)) -}]
+    _ <- phi1 work "block_index" [(indexLocal, claim), (indexGlobal, claimGlobalSuccess), (indexSteal, claimStealSuccess)]
     return ()
 
   instr_ $ downcast $ "sequential_mode" := Cmp singleType Compare.EQ index nextIfSeq
@@ -363,6 +444,21 @@ workassistLoop counter workPerThread maxClaim threadIndex maxThreads size doWork
 
   setBlock exit
   retval_ $ scalar (scalarType @Word8) 0
+  where
+    -- Unpacks a value from workPerThread
+    unpackWorkRange :: Operands Word64 -> CodeGen Native (Operands Word64, Operands Int64)
+    unpackWorkRange packed = do
+      start <- A.shiftR TypeWord64 packed (A.liftInt 16)
+      let sizeMask = (1 `shiftL` 16) - 1
+      size' <- A.band TypeWord64 packed (A.liftWord64 sizeMask)
+      -- Convert to signed 16 bit number
+      size16 <- A.fromIntegral TypeWord64 numType size'
+      rangeSize <- A.fromIntegral TypeInt16 numType size16
+      return (start, rangeSize)
+    
+    packWorkRange :: Operands Word64 -> Operands Word64 -> CodeGen Native (Operands Word64)
+    packWorkRange start size =
+      A.shiftL TypeWord64 start (A.liftInt 16) >>= A.bor TypeWord64 size
 
 workassistChunked :: [Loop.LoopAnnotation] -> ShapeR sh -> Operand (Ptr Word64) -> Operand (Ptr Word64) -> Word64 -> Operand Word32 -> Operand Word32 -> sh -> Operands sh -> (Operands sh -> CodeGen Native ()) -> CodeGen Native ()
 workassistChunked ann shr counter workPerThread maxClaim threadIndex maxThreads chunkSz' sh doWork = do

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Schedule.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Schedule.hs
@@ -880,7 +880,7 @@ convert inAwhile (Effect effect@(Exec _ kernel kargs) next)
       threadsPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       _ <- instr' $ Store NonVolatile threadsPtr (integral TypeWord32 0) Nothing -- active_threads
       workIdxPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
-      _ <- instr' $ Store NonVolatile workIdxPtr (integral TypeWord64 1) Nothing -- work_index
+      _ <- instr' $ Store NonVolatile workIdxPtr (integral TypeWord64 0) Nothing -- work_index
 
       when Debug.tracyIsEnabled $ do
         let name = kernelName kernel

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Schedule.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Schedule.hs
@@ -870,16 +870,16 @@ convert inAwhile (Effect effect@(Exec _ kernel kargs) next)
       -- Header
       workFnPtr' <- instr' $ GetElementPtr $ gepStruct kernelTp imports (tupleLeft importsIdx)
       workFn <- instr' $ Load NonVolatile workFnPtr' Nothing
-      workFnPtr <- instr' $ GetElementPtr $ gepStruct kernelTp args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft TupleIdxSelf)
+      workFnPtr <- instr' $ GetElementPtr $ gepStruct kernelTp args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft TupleIdxSelf)
       _ <- instr' $ Store NonVolatile workFnPtr workFn Nothing
-      programPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      programPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       _ <- instr' $ Store NonVolatile programPtr operandProgram Nothing
       location <- computeLocation inAwhile $ fromIntegral nextBlock
-      locationPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      locationPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       _ <- instr' $ Store NonVolatile locationPtr location Nothing
-      threadsPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      threadsPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       _ <- instr' $ Store NonVolatile threadsPtr (integral TypeWord32 0) Nothing -- active_threads
-      workIdxPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
+      workIdxPtr <- instr' $ GetElementPtr $ gepStruct primType args (TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxLeft $ TupleIdxRight TupleIdxSelf)
       _ <- instr' $ Store NonVolatile workIdxPtr (integral TypeWord64 0) Nothing -- work_index
 
       when Debug.tracyIsEnabled $ do

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Target.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Target.hs
@@ -65,9 +65,6 @@ instance Intrinsic Native where
     -- So instead of using llvm.trap, we call the abort function from the C standard library.
     -- This is also what llvm.trap would be lowered to if the target does not have a trap instruction.
     -- See: https://llvm.org/docs/LangRef.html#llvm-trap-intrinsic
-    --
-    -- TODO: This was tested when we used 'puts', but now we use 'printf' (via putString).
-    -- We should test this again.
     if Info.os == "mingw32"
       then abort
       else trap

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen.hs
@@ -489,6 +489,7 @@ parCodeGenScan descending foldOrScan inclusiveness fun seed input index codeSeed
           -- Wait on our turn
           _ <- Loop.while [] TupRunit
             (\_ -> do
+              -- TODO: Change to atomic load?
               idx <- instr $ Load Volatile idxPtr Nothing
               A.neq singleType idx (envsTileIndex envs)
             )
@@ -528,6 +529,7 @@ parCodeGenScan descending foldOrScan inclusiveness fun seed input index codeSeed
 
           _ <- instr' $ LLVM.Fence (CrossThread, Release)
           OP_Int nextIdx <- A.add numType (envsTileIndex envs) (A.liftInt 1)
+          -- TODO: Change to atomic store?
           _ <- instr' $ Store Volatile idxPtr nextIdx Nothing
           return exclusive
     

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
@@ -598,6 +598,7 @@ shfl_op sop t mask delta val
 sharedMemAddrSpace :: AddrSpace
 sharedMemAddrSpace = AddrSpace 3
 
+-- TODO: Should we change volatile loads and stores to shared memory to atomic loads and stores?
 sharedMemVolatility :: Volatility
 sharedMemVolatility = Volatile
 
@@ -813,11 +814,11 @@ nanosleep ns = do
 -- -------------------------
 
 codeGenKernel
-  :: forall arch f a. (HasCallStack, Target arch, Intrinsic arch, Result f ~ ())
+  :: forall f a. (HasCallStack, Result f ~ ())
   => String
   -> (forall k. Function k () -> Function k f)
-  -> CodeGen arch a
-  -> LLVM arch (a, Module f)
+  -> CodeGen PTX a
+  -> LLVM PTX (a, Module f)
 codeGenKernel name args body =
   codeGenFunction Nothing name VoidType args $ do
     addNamedMetadata "nvvm.annotations"

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Loop.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Loop.hs
@@ -76,6 +76,8 @@ loopSelfScheduled counter size doWork = do
   __syncthreads
   perThreadBlock $ do
     claimed <- Loop.atomicAdd Monotonic counter (integral TypeWord64 1)
+    -- TODO: Should we change the volatile operations to normal non-volatile
+    -- operations, or atomic operations?
     _ <- instr' $ Store Volatile index claimed Nothing
     return ()
   __syncthreads

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Arithmetic.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Arithmetic.hs
@@ -624,6 +624,10 @@ liftInt = lift $ TupRsingle scalarTypeInt
 liftInt32 :: Int32 -> Operands Int32
 liftInt32 = lift $ TupRsingle scalarTypeInt32
 
+{-# INLINE liftInt64 #-}
+liftInt64 :: Int64 -> Operands Int64
+liftInt64 = lift $ TupRsingle scalarType
+
 {-# INLINE liftWord8 #-}
 liftWord8 :: Word8 -> Operands Word8
 liftWord8 = lift $ TupRsingle scalarType

--- a/accelerate-llvm/src/LLVM/AST/Type/Instruction.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Instruction.hs
@@ -41,6 +41,7 @@ import Data.Array.Accelerate.AST                          ( PrimBool )
 import Data.Array.Accelerate.AST.Idx
 import qualified Data.Array.Accelerate.Debug.Internal     as Debug
 import Data.Array.Accelerate.Error
+import Data.Array.Accelerate.Representation.Elt
 import Data.Array.Accelerate.Representation.Type
 import Data.Primitive.Vec
 
@@ -217,6 +218,11 @@ data Instruction a where
                   -> Operand (Ptr a)
                   -> Maybe Align
                   -> Instruction a
+  
+  AtomicLoad      :: SingleType a
+                  -> Operand (Ptr a)
+                  -> MemoryOrdering
+                  -> Instruction a
 
   -- <http://llvm.org/docs/LangRef.html#store-instruction>
   --
@@ -224,6 +230,12 @@ data Instruction a where
                   -> Operand (Ptr a)
                   -> Operand a
                   -> Maybe Align
+                  -> Instruction ()
+
+  AtomicStore     :: SingleType a
+                  -> Operand (Ptr a)
+                  -> Operand a
+                  -> MemoryOrdering
                   -> Instruction ()
 
   -- <http://llvm.org/docs/LangRef.html#getelementptr-instruction>
@@ -377,6 +389,8 @@ data Instruction a where
 -- don't need names.
 --
 data Named ins a where
+  -- TODO: This should be 'ins (ops a)' (actually 'CodeGen arch (Operands a)') in some cases.
+  -- We should try to find a way to encode this properly.
   (:=) :: Name a -> ins a -> Named ins a
   Do   :: ins ()          -> Named ins ()
 
@@ -407,6 +421,8 @@ instance Downcast (Instruction a) LP.Instr where
     Alloca tp             -> LP.Alloca (downcast tp) Nothing Nothing
     Store vol p x align   -> LP.Store (downcast vol) (downcast x) (downcast p) atomicity align
     Load vol p align      -> LP.Load (downcast vol) (downcast $ pointeeType $ typeOf p) (downcast p) atomicity align
+    AtomicStore tp p x m  -> LP.Store False (downcast x) (downcast p) (Just $ downcast m) (Just $ singleTypeSize tp)
+    AtomicLoad tp p m     -> LP.Load False (downcast tp) (downcast p) (Just $ downcast m) (Just $ singleTypeSize tp)
     GetElementPtr (GEP n i1 path) -> case typeOf n of
       PrimType (PtrPrimType t _) ->
         LP.GEP inbounds (downcast t) (downcast n) (downcast i1 : downcastGEPIndex constantTyped path t)
@@ -618,6 +634,8 @@ instance TypeOf Instruction where
     Alloca t              -> PrimType $ PtrPrimType t defaultAddrSpace
     Load _ ptr _          -> PrimType $ pointeeType $ typeOf ptr
     Store{}               -> VoidType
+    AtomicLoad t _ _      -> PrimType $ ScalarPrimType $ SingleScalarType t
+    AtomicStore{}         -> VoidType
     GetElementPtr gep     -> typeOf gep
     Fence{}               -> VoidType
     CmpXchg t _ _ _ _ _ _ -> PrimType . StructPrimType False $ ScalarPrimType (SingleScalarType (NumSingleType (IntegralNumType t))) `pair` primType


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->
This pull requests adds a new data-parallel scheduler, a data-parallel variant of work stealing, for use in kernels on the CPU. This is an alternative scheduling algorithm to #4. Both schedulers improve the performance over the current self scheduling in two ways:

1. Reduced scheduling overhead due to lower contention on the atomic counter (denoting the next unclaimed tile).
2. Improved cache locality.

The algorithm in this PR was based on the results of Koen's work (his thesis and #4).

## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

This PR has the similar goals as #4. Differences:

1. #4 also improves performance of non-commutative folds. This PR doesn't improve that, but I expect/hope we can improve those via interleaved chained scans (https://studenttheses.uu.nl/items/3ef19878-f012-49c9-a86d-df79e1bd7c2d).
2. This algorithm is (I think) simpler in terms of complexity and maintenance.

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->
Test suite, and CFAL for benchmarking (especially MG)
